### PR TITLE
Use env var in CI workflow to decide whether to deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,16 +247,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs:
-      - lint-black
-      - lint-flake8
-      - lint-isort
-      - lint-mypy
-      - lint-bandit
-      - lint-django-doctor
-      - test-unit
-      - test-integration
-      - test-functional
     steps:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
@@ -272,10 +262,35 @@ jobs:
           platforms: linux/arm/v7
           tags: "ghcr.io/${{ github.repository }}:latest"
 
+  # ------
+  # Deploy
+  # ------
+
+  # Gate job to control whether the image should be deployed.
+  deploy-gate:
+    runs-on: ubuntu-latest
+    # Only allow deploys from the main branch.
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      # Make sure all of the tests and linters have passed.
+      - lint-black
+      - lint-flake8
+      - lint-isort
+      - lint-mypy
+      - lint-bandit
+      - lint-django-doctor
+      - test-unit
+      - test-integration
+      - test-functional
+      # Make sure the image that will be deployed has been built and published.
+      - build
+    steps:
+      - run: ':'
+
   release:
     runs-on: ubuntu-latest
     needs:
-      - build
+      - deploy-gate
     continue-on-error: true
     steps:
       - uses: actions/checkout@v2
@@ -289,9 +304,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
-      - build
+      - deploy-gate
     steps:
       - uses: appleboy/ssh-action@v0.1.4
         env:


### PR DESCRIPTION
Prior to this change, we has checks for the main branch whenever we
wanted to restrict a job to only run on deployment runs.

This change adds an env var for this to make the decision clearer.
